### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@
 ```
 
 ```
-composer require php-http/guzzle6-adapter moravianlibrary/ziskej-api-php-client
+composer require moravianlibrary/ziskej-api-php-client
 ```
 


### PR DESCRIPTION
php-http/guzzle6-adapter is in require-dev in composer.json, so installed by default